### PR TITLE
Add shared Dockerfiles using the `ACTOR_PATH_IN_DOCKER_CONTEXT` build arg

### DIFF
--- a/actors/javascript-actor/.actor/actor.json
+++ b/actors/javascript-actor/.actor/actor.json
@@ -7,5 +7,5 @@
     "dockerContextDir": "../../..",
     "input": "../../../shared/input_schema.json",
     "readme": "./README.md",
-    "dockerfile": "./Dockerfile"
+    "dockerfile": "../../../shared/JavaScript_Dockerfile"
 }

--- a/actors/typescript-actor/.actor/actor.json
+++ b/actors/typescript-actor/.actor/actor.json
@@ -7,5 +7,5 @@
     "dockerContextDir": "../../..",
     "input": "../../../shared/input_schema.json",
     "readme": "./README.md",
-    "dockerfile": "./Dockerfile"
+    "dockerfile": "../../../shared/TypeScript_Dockerfile"
 }

--- a/shared/JavaScript_Dockerfile
+++ b/shared/JavaScript_Dockerfile
@@ -1,10 +1,11 @@
 FROM apify/actor-node:16
+ARG ACTOR_PATH_IN_DOCKER_CONTEXT
 
 # Copy root package*.json
 COPY package*.json ./
 
 # Copy package.jsons of all used workspace members
-COPY actors/javascript-actor/package*.json actors/javascript-actor/
+COPY "${ACTOR_PATH_IN_DOCKER_CONTEXT}/package*.json" "${ACTOR_PATH_IN_DOCKER_CONTEXT}/"
 COPY packages/javascript-utils/package*.json packages/javascript-utils/
 
 
@@ -22,8 +23,9 @@ RUN npm --quiet set progress=false \
     && rm -r ~/.npm
 
 # Copy the rest of the source files.
-COPY actors/javascript-actor actors/javascript-actor/
+COPY "${ACTOR_PATH_IN_DOCKER_CONTEXT}" "./${ACTOR_PATH_IN_DOCKER_CONTEXT}"
 COPY packages packages/
 
 # Run the actor's start command when running this image
-CMD npm run -w actors/javascript-actor start
+ENV ACTOR_PATH_IN_DOCKER_CONTEXT="${ACTOR_PATH_IN_DOCKER_CONTEXT}"
+CMD npm run -w "${ACTOR_PATH_IN_DOCKER_CONTEXT}" start

--- a/shared/TypeScript_Dockerfile
+++ b/shared/TypeScript_Dockerfile
@@ -1,12 +1,14 @@
 # Build the TypeScript code in a separate stage, to reduce the size of the final image.
 FROM apify/actor-node:16 AS builder
+ARG ACTOR_PATH_IN_DOCKER_CONTEXT
+
 WORKDIR /app
 
 # Copy root package*.json
 COPY package*.json ./
 
 # Copy package.jsons of all used workspace members
-COPY actors/typescript-actor/package*.json actors/typescript-actor/
+COPY "${ACTOR_PATH_IN_DOCKER_CONTEXT}/package*.json" "${ACTOR_PATH_IN_DOCKER_CONTEXT}/"
 COPY packages/javascript-utils/package*.json packages/javascript-utils/
 COPY packages/typescript-utils/package*.json packages/typescript-utils/
 
@@ -14,23 +16,24 @@ COPY packages/typescript-utils/package*.json packages/typescript-utils/
 RUN npm install --include=dev --audit=false
 
 # Next, copy the rest of the source files.
-COPY actors/typescript-actor actors/typescript-actor/
+COPY "${ACTOR_PATH_IN_DOCKER_CONTEXT}" "./${ACTOR_PATH_IN_DOCKER_CONTEXT}"
 COPY packages packages/
 COPY tsconfig.build.json ./
 
 # Build the TypeScript libraries
-RUN npm run -w actors/typescript-actor build
+RUN npm run -w "${ACTOR_PATH_IN_DOCKER_CONTEXT}" build
 
 
 
 # Create the final image, only with compiled code and production dependencies.
 FROM apify/actor-node:16
+ARG ACTOR_PATH_IN_DOCKER_CONTEXT
 
 # Copy root package*.json
 COPY package*.json ./
 
 # Copy package.jsons of all workspace members
-COPY actors/typescript-actor/package*.json actors/typescript-actor/
+COPY "${ACTOR_PATH_IN_DOCKER_CONTEXT}/package*.json" "${ACTOR_PATH_IN_DOCKER_CONTEXT}/"
 COPY packages/javascript-utils/package*.json packages/javascript-utils/
 COPY packages/typescript-utils/package*.json packages/typescript-utils/
 
@@ -48,12 +51,13 @@ RUN npm --quiet set progress=false \
     && rm -r ~/.npm
 
 # Copy the rest of the source files.
-COPY actors/typescript-actor actors/typescript-actor/
+COPY "${ACTOR_PATH_IN_DOCKER_CONTEXT}" "./${ACTOR_PATH_IN_DOCKER_CONTEXT}"
 COPY packages packages/
 
 # Copy built JS files from the `builder` stage
-COPY --from=builder /app/actors/typescript-actor/dist actors/typescript-actor/dist
+COPY --from=builder "/app/${ACTOR_PATH_IN_DOCKER_CONTEXT}/dist" "${ACTOR_PATH_IN_DOCKER_CONTEXT}/dist"
 COPY --from=builder /app/packages/typescript-utils/dist packages/typescript-utils/dist
 
 # Run the actor's start command when running this image
-CMD npm run -w actors/typescript-actor start:prod
+ENV ACTOR_PATH_IN_DOCKER_CONTEXT="${ACTOR_PATH_IN_DOCKER_CONTEXT}"
+CMD npm run -w "${ACTOR_PATH_IN_DOCKER_CONTEXT}" start:prod


### PR DESCRIPTION
To enable sharing of Dockerfiles between Actors in a monorepo, we've added the `ACTOR_PATH_IN_CONTEXT` build arg to the Actor build context. It contains the relative path from `dockerContextDir` to the directory selected as the root of the Actor - usually it will be the "folder" part of the Actor's git URL.

This PR changes the monorepo example to utilize that build arg - it moves the `Dockerfile`s to the `shared` folder, and changes them to always copy the right Actor's files based on that arg - so now you can have multiple Actors in one monorepo but just one Dockerfile for them all together (or one Dockerfile per Actor technology, really).